### PR TITLE
Add support for cloud-init user data

### DIFF
--- a/src/vpc/node_provider.py
+++ b/src/vpc/node_provider.py
@@ -477,6 +477,9 @@ class IBMVPCNodeProvider(NodeProvider):
         instance_prototype["boot_volume_attachment"] = boot_volume_attachment
         instance_prototype["primary_network_interface"] = primary_network_interface
 
+        if "user_data" in base_config:
+            instance_prototype["user_data"] = base_config["user_data"]
+
         try:
             with self.lock:
                 resp = self.ibm_vpc_client.create_instance(instance_prototype)

--- a/src/vpc/node_provider.py
+++ b/src/vpc/node_provider.py
@@ -480,6 +480,9 @@ class IBMVPCNodeProvider(NodeProvider):
         if "user_data" in base_config:
             instance_prototype["user_data"] = base_config["user_data"]
 
+        if "metadata_service" in base_config:
+            instance_prototype["metadata_service"] = base_config["metadata_service"]
+
         try:
             with self.lock:
                 resp = self.ibm_vpc_client.create_instance(instance_prototype)


### PR DESCRIPTION
Being able to pass a cloud-init user data string is useful for a lot of things including changing the default user. This can be used to make ray run with non-root and non-sudo user.